### PR TITLE
Fix: Remove ending slash in containerPath

### DIFF
--- a/terraform/templates/django_app.json.tpl
+++ b/terraform/templates/django_app.json.tpl
@@ -42,7 +42,7 @@
     ],
     "mountPoints": [
       {
-        "containerPath": "/usr/src/app/staticfiles/",
+        "containerPath": "/usr/src/app/staticfiles",
         "sourceVolume": "static_volume"
       }
     ],
@@ -71,7 +71,7 @@
     ],
     "mountPoints": [
       {
-        "containerPath": "/usr/src/app/staticfiles/",
+        "containerPath": "/usr/src/app/staticfiles",
         "sourceVolume": "static_volume"
       }
     ],


### PR DESCRIPTION
As I commented on reddit

```
I find out that static files are not serve well in ECS instance.
After I removed ending slash in container path it worked well.
```

https://www.reddit.com/r/django/comments/i8zdto/deploying_django_to_aws_ecs_with_terraform/