### PR TITLE
Update vpc zone identifier for autoscaling group

### DIFF
--- a/terraform/09_auto_scaling.tf
+++ b/terraform/09_auto_scaling.tf
@@ -5,5 +5,5 @@ resource "aws_autoscaling_group" "ecs-cluster" {
   desired_capacity     = var.autoscale_desired
   health_check_type    = "EC2"
   launch_configuration = aws_launch_configuration.ecs.name
-  vpc_zone_identifier  = [aws_subnet.public-subnet-1.id, aws_subnet.public-subnet-2.id]
+  vpc_zone_identifier  = [aws_subnet.private-subnet-1.id, aws_subnet.private-subnet-2.id]
 }


### PR DESCRIPTION
In the project setup, the auto scaling group is applied for the ECS cluster, which is located in the private subnets as show in this [image](https://testdriven.io/static/images/blog/django-ecs-terraform/aws-architecture.png).
Thus, the [vpc_zone_identifier](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#vpc_zone_identifier) should be changed to the private subnets.